### PR TITLE
Remove pooling and refactor GroupNorm

### DIFF
--- a/convert_jax_to_pytroch.py
+++ b/convert_jax_to_pytroch.py
@@ -103,8 +103,8 @@ def convert_jax_conv_state_dict_to_torch_conv_state_dict(jax_state_dict):
 
 def convert_jax_norm_state_dict_to_torch_norm_state_dict(jax_state_dict):
     return {
-        "weight": torch.Tensor(jax_state_dict["scale"].tolist()),
-        "bias": torch.Tensor(jax_state_dict["bias"].tolist()),
+        "group_norm.weight": torch.Tensor(jax_state_dict["scale"].tolist()),
+        "group_norm.bias": torch.Tensor(jax_state_dict["bias"].tolist()),
     }
 
 
@@ -115,8 +115,8 @@ def apply_pretrained_resnet10_params(model, params):
 
     model.embedder[1].load_state_dict(
         {
-            "weight": torch.Tensor(params["norm_init"]["scale"].tolist()),
-            "bias": torch.Tensor(params["norm_init"]["bias"].tolist()),
+            "group_norm.weight": torch.Tensor(params["norm_init"]["scale"].tolist()),
+            "group_norm.bias": torch.Tensor(params["norm_init"]["bias"].tolist()),
         },
         strict=True,
     )

--- a/resnet_10/modeling_resnet.py
+++ b/resnet_10/modeling_resnet.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from torch import Tensor
 from transformers import PreTrainedModel
 from transformers.activations import ACT2FN
-from transformers.modeling_outputs import BaseModelOutputWithNoAttention, BaseModelOutputWithPoolingAndNoAttention
+from transformers.modeling_outputs import BaseModelOutputWithNoAttention
 
 from .configuration_resnet import ResNet10Config
 
@@ -238,31 +238,6 @@ class ResNet10(PreTrainedModel):
         )
 
         self.encoder = Encoder(self.config)
-        self.pooler = nn.AdaptiveAvgPool2d(output_size=1)
-
-    def _init_pooler(self):
-        if self.config.pooler == "avg":
-            self.pooler = nn.AdaptiveAvgPool2d(output_size=1)
-        elif self.config.pooler == "max":
-            self.pooler = nn.MaxPool2d(kernel_size=3, stride=2)
-        elif self.config.pooler == "spatial_learned_embeddings":
-            raise ValueError("Invalid pooler, it exist in the hil serl version, but weights are missing")
-
-            # In the original HIl-SERL code is used SpatialLearnedEmbeddings as pooliing method
-            # Check https://github.com/rail-berkeley/hil-serl/blob/7d17d13560d85abffbd45facec17c4f9189c29c0/serl_launcher/serl_launcher/agents/continuous/sac.py#L490
-            # But weights for this custom layer are missing
-            # Probably it means that pretrained weights used other way of pooling - probably it's AvgPool2d
-            # self.pooler = nn.Sequential(
-            #     SpatialLearnedEmbeddings(
-            #         height=height,
-            #         width=width,
-            #         channel=channel,
-            #         num_features=self.num_spatial_blocks,
-            #     ),
-            #     nn.Dropout(0.1, deterministic=not train),
-            # )
-        else:
-            raise ValueError(f"Invalid pooler: {self.config.pooler}")
 
     def forward(self, x: Tensor, output_hidden_states: Optional[bool] = None) -> BaseModelOutputWithNoAttention:
         output_hidden_states = (
@@ -271,12 +246,9 @@ class ResNet10(PreTrainedModel):
         embedding_output = self.embedder(x)
         encoder_outputs = self.encoder(embedding_output, output_hidden_states=output_hidden_states)
 
-        pooler_output = self.pooler(encoder_outputs.last_hidden_state)
-
-        return BaseModelOutputWithPoolingAndNoAttention(
+        return BaseModelOutputWithNoAttention(
             last_hidden_state=encoder_outputs.last_hidden_state,
             hidden_states=encoder_outputs.hidden_states,
-            pooler_output=pooler_output,
         )
 
     def print_model_hash(self):


### PR DESCRIPTION
# What this does

- Remove pooling logic from ResNet10 model.
- Refactor GroupNorm implementation to work with inputs without batch dim.

# How it was tested

Tested it with HIL-SERL LeRobot training scripts.